### PR TITLE
feat(auth): implement PASETO token generation and verification

### DIFF
--- a/.env
+++ b/.env
@@ -44,3 +44,9 @@ CODE_ODESSEY_HOST_DATA_DIR=./data
 
 # Temporal inclusion for test
 CODE_ODESSEY_DATABASE_URI=postgres://postgres:postgres@localhost:5432/codeodessey?sslmode=disable
+
+###############
+#### Token ####
+###############
+
+CODE_ODESSEY_TOKEN_DURATION = "120m"

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 
 type Config struct {
 	Environment string `mapstructure:"CODE_ODESSEY_ENVIRONMENT"`
+	Duration    string `mapstructure:"CODE_ODESSEY_TOKEN_DURATION"`
 	DBDriver    string `mapstructure:"CODE_ODESSEY_DB_DRIVER"`
 	DBSource    string `mapstructure:"CODE_ODESSEY_DATABASE_URI"`
 	DBHost      string `mapstructure:"CODE_ODESSEY_DB_HOST"`

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/teamkweku/code-odessey-hex-arch
 go 1.23.0
 
 require (
+	aidanwoods.dev/go-paseto v1.5.2
 	github.com/TeamKweku/code-odessey-hex-arch-proto v0.0.7
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
@@ -17,6 +18,7 @@ require (
 )
 
 require (
+	aidanwoods.dev/go-result v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+aidanwoods.dev/go-paseto v1.5.2 h1:9aKbCQQUeHCqis9Y6WPpJpM9MhEOEI5XBmfTkFMSF/o=
+aidanwoods.dev/go-paseto v1.5.2/go.mod h1:7eEJZ98h2wFi5mavCcbKfv9h86oQwut4fLVeL/UBFnw=
+aidanwoods.dev/go-result v0.1.0 h1:y/BMIRX6q3HwaorX1Wzrjo3WUdiYeyWbvGe18hKS3K8=
+aidanwoods.dev/go-result v0.1.0/go.mod h1:yridkWghM7AXSFA6wzx0IbsurIm1Lhuro3rYef8FBHM=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=

--- a/internal/adapters/inbound/auth/paseto_token.go
+++ b/internal/adapters/inbound/auth/paseto_token.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	"aidanwoods.dev/go-paseto"
+
+	"github.com/teamkweku/code-odessey-hex-arch/config"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/ports/inbound"
+)
+
+/**
+* PasetoToken implements the port inbound.TokenService interface
+ */
+type PasetoToken struct {
+	token  *paseto.Token
+	key    *paseto.V4SymmetricKey
+	parser *paseto.Parser
+}
+
+// New creates a new paseto instance and returns an token interface
+// just to make sure the function implements all methods of interface
+// CreateToken & VerifyToken methods
+func NewPasetoToken() (inbound.TokenService, error) {
+	token := paseto.NewToken()
+	key := paseto.NewV4SymmetricKey()
+	parser := paseto.NewParser()
+
+	return &PasetoToken{
+		token:  &token,
+		key:    &key,
+		parser: &parser,
+	}, nil
+}
+
+// CreateToken creates a new paseto token
+func (pt *PasetoToken) CreateToken(
+	user *user.User,
+	cfg config.Config,
+) (string, *auth.Payload, error) {
+	payload, err := auth.NewPayload(user, cfg)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to set token payload: %w", err)
+	}
+
+	err = pt.token.Set("payload", payload)
+	if err != nil {
+		return "", nil, fmt.Errorf(
+			"failed to set token payload: %w",
+			auth.NewTokenCreationError("token payload error"),
+		)
+	}
+
+	pt.token.SetIssuedAt(payload.IssuedAt)
+	pt.token.SetNotBefore(payload.IssuedAt)
+	pt.token.SetExpiration(payload.ExpiredAt)
+
+	token := pt.token.V4Encrypt(*pt.key, nil)
+
+	return token, payload, nil
+}
+
+func (pt *PasetoToken) VerifyToken(tokenstring string) (*auth.Payload, error) {
+	var payload *auth.Payload
+
+	parsedToken, err := pt.parser.ParseV4Local(*pt.key, tokenstring, nil)
+	if err != nil {
+		if err.Error() == "this token has expired" {
+			return nil, fmt.Errorf("token has expired: %w", auth.NewExpiredTokenError(time.Now()))
+		}
+		return nil, fmt.Errorf("invalid token: %w", auth.NewInvalidTokenError("token error"))
+	}
+
+	err = parsedToken.Get("payload", &payload)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid token payload %w",
+			auth.NewInvalidTokenError("payload error"),
+		)
+	}
+
+	// Normalize time zones to UTC
+	payload.IssuedAt = payload.IssuedAt.UTC()
+	payload.ExpiredAt = payload.ExpiredAt.UTC()
+
+	return payload, nil
+}

--- a/internal/adapters/inbound/auth/paseto_token_test.go
+++ b/internal/adapters/inbound/auth/paseto_token_test.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/teamkweku/code-odessey-hex-arch/config"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
+)
+
+func TestPasetoToken_CreateToken(t *testing.T) {
+	t.Parallel()
+
+	pt, err := NewPasetoToken()
+	require.NoError(t, err)
+
+	usr := user.RandomUser(t)
+	cfg := config.Config{
+		Duration: "30m",
+	}
+
+	token, payload, err := pt.CreateToken(usr, cfg)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.NotNil(t, payload)
+}
+
+func TestPasetoToken_VerifyToken(t *testing.T) {
+	t.Parallel()
+
+	pt, err := NewPasetoToken()
+	require.NoError(t, err)
+
+	usr := user.RandomUser(t)
+	cfg := config.Config{
+		Duration: "30m",
+	}
+
+	token, payload, err := pt.CreateToken(usr, cfg)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.NotNil(t, payload)
+
+	verifiedPayload, err := pt.VerifyToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, payload, verifiedPayload)
+}
+
+func TestPasetoToken_VerifyToken_Expired(t *testing.T) {
+	t.Parallel()
+
+	pt, err := NewPasetoToken()
+	require.NoError(t, err)
+
+	usr := user.RandomUser(t)
+	cfg := config.Config{
+		Duration: "10ms", // Set a short duration for testing expiration
+	}
+
+	token, payload, err := pt.CreateToken(usr, cfg)
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.NotNil(t, payload)
+
+	// Simulate token expiration
+	time.Sleep(15 * time.Millisecond)
+
+	_, err = pt.VerifyToken(token)
+	assert.Error(t, err)
+	var expiredErr *auth.ValidationError
+	assert.ErrorAs(t, err, &expiredErr)
+	assert.Equal(t, auth.ExpiredTokenFieldtype, expiredErr.Field)
+}

--- a/internal/core/application/auth/auth_service.go
+++ b/internal/core/application/auth/auth_service.go
@@ -1,0 +1,27 @@
+package auth
+
+import (
+	"github.com/teamkweku/code-odessey-hex-arch/config"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/ports/inbound"
+)
+
+type AuthService struct {
+	tokenService inbound.TokenService
+}
+
+func NewAuthService(tokenService inbound.TokenService) *AuthService {
+	return &AuthService{tokenService}
+}
+
+func (as *AuthService) CreateToken(
+	user *user.User,
+	cfg config.Config,
+) (string, *auth.Payload, error) {
+	return as.tokenService.CreateToken(user, cfg)
+}
+
+func (as *AuthService) VerifyToken(token string) (*auth.Payload, error) {
+	return as.tokenService.VerifyToken(token)
+}

--- a/internal/core/application/auth/auth_service.go
+++ b/internal/core/application/auth/auth_service.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"fmt"
+
 	"github.com/teamkweku/code-odessey-hex-arch/config"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
@@ -19,9 +21,19 @@ func (as *AuthService) CreateToken(
 	user *user.User,
 	cfg config.Config,
 ) (string, *auth.Payload, error) {
-	return as.tokenService.CreateToken(user, cfg)
+	token, payload, err := as.tokenService.CreateToken(user, cfg)
+	if err != nil {
+		return "", nil, fmt.Errorf("auth service - create token: %w", err)
+	}
+
+	return token, payload, nil
 }
 
 func (as *AuthService) VerifyToken(token string) (*auth.Payload, error) {
-	return as.tokenService.VerifyToken(token)
+	payload, err := as.tokenService.VerifyToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("auth service - verify token: %w", err)
+	}
+
+	return payload, nil
 }

--- a/internal/core/domain/auth/errors.go
+++ b/internal/core/domain/auth/errors.go
@@ -1,0 +1,121 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type FieldType int
+
+const (
+	UUIDFieldType FieldType = iota + 1
+	TokenFieldType
+	TimeRangeFieldType
+	DurationFieldType
+	ExpiredTokenFieldtype
+	SecretKeyFieldType
+	TokenCreationFieldType
+)
+
+var fieldNames = [7]string{
+	"uuid",
+	"token",
+	"time range",
+	"expired token",
+	"secret key",
+	"token creation",
+}
+
+func (f FieldType) String() string {
+	if int(f) > len(fieldNames) {
+		return "unknown"
+	}
+	return fieldNames[f-1]
+}
+
+type ValidationError struct {
+	Field   FieldType
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("{Field: %q, Message: %q}", e.Field, e.Message)
+}
+
+type ValidationErrors []error
+
+func (ve ValidationErrors) Error() string {
+	if len(ve) == 0 {
+		return "validation errors:\n"
+	}
+
+	msg := "validation errors:\n"
+	for _, err := range ve {
+		msg += fmt.Sprintf("\t- %s\n", err)
+	}
+	return msg
+}
+
+func (ve *ValidationErrors) PushValidationError(err error) error {
+	var validationErr *ValidationError
+	if err == nil {
+		return nil
+	}
+	if !errors.As(err, &validationErr) {
+		return fmt.Errorf("unexpected error type: %T", err)
+	}
+	*ve = append(*ve, validationErr)
+	return nil
+}
+
+func (ve ValidationErrors) Any() bool {
+	return len(ve) > 0
+}
+
+func NewInvalidUUIDError(value string) error {
+	return &ValidationError{
+		Field:   UUIDFieldType,
+		Message: fmt.Sprintf("invalid UUID: %s", value),
+	}
+}
+
+func NewInvalidTokenError(reason string) error {
+	return &ValidationError{
+		Field:   TokenFieldType,
+		Message: fmt.Sprintf("invalid token: %s", reason),
+	}
+}
+
+func NewInvalidTimeRangeError(issuedAt, expiredAt time.Time) error {
+	return &ValidationError{
+		Field: TimeRangeFieldType,
+		Message: fmt.Sprintf(
+			"invalid time range: IssuedAt (%s) must be before ExpiredAt (%s)",
+			issuedAt,
+			expiredAt,
+		),
+	}
+}
+
+func NewInvalidDurationError(duration time.Duration, reason string) error {
+	return &ValidationError{
+		Field:   DurationFieldType,
+		Message: fmt.Sprintf("invalid duration %v: %s", duration, reason),
+	}
+}
+
+func NewExpiredTokenError(expiredAt time.Time) error {
+	return &ValidationError{
+		Field:   ExpiredTokenFieldtype,
+		Message: fmt.Sprintf("invalid expired at time %s", expiredAt.String()),
+	}
+}
+
+// Added NewTokenCreationError function
+func NewTokenCreationError(reason string) error {
+	return &ValidationError{
+		Field:   TokenCreationFieldType,
+		Message: fmt.Sprintf("failed to create token: %s", reason),
+	}
+}

--- a/internal/core/domain/auth/models.go
+++ b/internal/core/domain/auth/models.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/teamkweku/code-odessey-hex-arch/config"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
+)
+
+type Payload struct {
+	ID        uuid.UUID `json:"id,omitempty"`
+	UserID    uuid.UUID `json:"user_id,omitempty"`
+	Role      string    `json:"role,omitempty"`
+	IssuedAt  time.Time `json:"issued_at,omitempty"`
+	ExpiredAt time.Time `json:"expired_at,omitempty"`
+}
+
+// New Payload creates a new token payload with specific username and duration
+func NewPayload(user *user.User, cfg config.Config) (*Payload, error) {
+	tokenID, err := uuid.NewRandom()
+	if err != nil {
+		return nil, NewInvalidUUIDError("invalid UUID creation error")
+	}
+
+	durationStr := cfg.Duration
+	duration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		return nil, NewInvalidDurationError(duration, "invalid token duration")
+	}
+
+	payload := &Payload{
+		ID:        tokenID,
+		UserID:    user.ID(),
+		Role:      user.Role().String(),
+		IssuedAt:  time.Now().UTC(),
+		ExpiredAt: time.Now().UTC().Add(duration),
+	}
+
+	return payload, nil
+}
+
+// Valid checks if token payload is valid or not
+func (p *Payload) Valid() error {
+	if time.Now().After(p.ExpiredAt) {
+		return NewExpiredTokenError(p.ExpiredAt)
+	}
+
+	return nil
+}

--- a/internal/core/domain/user/validation.go
+++ b/internal/core/domain/user/validation.go
@@ -180,6 +180,18 @@ func ParseRole(candidate int) (Role, error) {
 	return Role(candidate), nil
 }
 
+// convert role string to int
+func RoleStringToInt(roleStr string) (int, error) {
+	switch roleStr {
+	case "Reader":
+		return int(RoleReader), nil
+	case "Admin":
+		return int(RoleAdmin), nil
+	default:
+		return -1, fmt.Errorf("unknown role: %s", roleStr)
+	}
+}
+
 // String returns the string representation of the Role
 func (r Role) String() string {
 	switch r {

--- a/internal/core/ports/inbound/auth_service.go
+++ b/internal/core/ports/inbound/auth_service.go
@@ -1,0 +1,12 @@
+package inbound
+
+import (
+	"github.com/teamkweku/code-odessey-hex-arch/config"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
+	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
+)
+
+type TokenService interface {
+	CreateToken(user *user.User, cfg config.Config) (string, *auth.Payload, error)
+	VerifyToken(token string) (*auth.Payload, error)
+}


### PR DESCRIPTION
- Create PasetoToken adapter for token operations
- Implement AuthService for token management
- Add TokenService interface in inbound ports
- Update user service to use AuthService for authentication
- Add tests for PasetoToken and AuthService
- Updated ValidationError to include auth token errors
- Update config and .env with duration variable for authentication
- test pasto_token generation and verification function