### PR TITLE
fix(sessions): replacing config with string duration variable in NewPayload

### DIFF
--- a/internal/adapters/inbound/auth/paseto_token.go
+++ b/internal/adapters/inbound/auth/paseto_token.go
@@ -6,7 +6,6 @@ import (
 
 	"aidanwoods.dev/go-paseto"
 
-	"github.com/teamkweku/code-odessey-hex-arch/config"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/ports/inbound"
@@ -39,9 +38,9 @@ func NewPasetoToken() (inbound.TokenService, error) {
 // CreateToken creates a new paseto token
 func (pt *PasetoToken) CreateToken(
 	user *user.User,
-	cfg config.Config,
+	durationStr string,
 ) (string, *auth.Payload, error) {
-	payload, err := auth.NewPayload(user, cfg)
+	payload, err := auth.NewPayload(user, durationStr)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to set token payload: %w", err)
 	}

--- a/internal/adapters/inbound/auth/paseto_token_test.go
+++ b/internal/adapters/inbound/auth/paseto_token_test.go
@@ -23,7 +23,7 @@ func TestPasetoToken_CreateToken(t *testing.T) {
 		AccessTokenDuration: "30m",
 	}
 
-	token, payload, err := pt.CreateToken(usr, cfg)
+	token, payload, err := pt.CreateToken(usr, cfg.AccessTokenDuration)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.NotNil(t, payload)
@@ -40,7 +40,7 @@ func TestPasetoToken_VerifyToken(t *testing.T) {
 		AccessTokenDuration: "30m",
 	}
 
-	token, payload, err := pt.CreateToken(usr, cfg)
+	token, payload, err := pt.CreateToken(usr, cfg.AccessTokenDuration)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.NotNil(t, payload)
@@ -61,7 +61,7 @@ func TestPasetoToken_VerifyToken_Expired(t *testing.T) {
 		AccessTokenDuration: "10ms", // Set a short duration for testing expiration
 	}
 
-	token, payload, err := pt.CreateToken(usr, cfg)
+	token, payload, err := pt.CreateToken(usr, cfg.AccessTokenDuration)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	assert.NotNil(t, payload)

--- a/internal/adapters/inbound/grpc/user/server.go
+++ b/internal/adapters/inbound/grpc/user/server.go
@@ -108,13 +108,13 @@ func (s *Server) Authenticate(
 	}
 
 	// generate access token
-	accessToken, accessPayload, err := s.authService.CreateToken(authenticatedUser, s.config)
+	accessToken, accessPayload, err := s.authService.CreateToken(authenticatedUser, s.config.AccessTokenDuration)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create access token: %v", err)
 	}
 
 	// create refresh token
-	refreshToken, refreshPayload, err := s.authService.CreateToken(authenticatedUser, s.config)
+	refreshToken, refreshPayload, err := s.authService.CreateToken(authenticatedUser, s.config.RefreshTokenDuration)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create refresh token: %v", err)
 	}

--- a/internal/core/application/auth/auth_service.go
+++ b/internal/core/application/auth/auth_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/teamkweku/code-odessey-hex-arch/config"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/application/session"
 
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
@@ -24,9 +23,9 @@ func NewAuthService(tokenService inbound.TokenService, sessionService *session.S
 
 func (as *AuthService) CreateToken(
 	user *user.User,
-	cfg config.Config,
+	durationStr string,
 ) (string, *auth.Payload, error) {
-	token, payload, err := as.tokenService.CreateToken(user, cfg)
+	token, payload, err := as.tokenService.CreateToken(user, durationStr)
 	if err != nil {
 		return "", nil, fmt.Errorf("auth service - create token: %w", err)
 	}

--- a/internal/core/domain/auth/payload.go
+++ b/internal/core/domain/auth/payload.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/teamkweku/code-odessey-hex-arch/config"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
 )
 
@@ -18,13 +17,12 @@ type Payload struct {
 }
 
 // New Payload creates a new token payload with specific username and duration
-func NewPayload(user *user.User, cfg config.Config) (*Payload, error) {
+func NewPayload(user *user.User, durationStr string) (*Payload, error) {
 	tokenID, err := uuid.NewRandom()
 	if err != nil {
 		return nil, NewInvalidUUIDError("invalid UUID creation error")
 	}
 
-	durationStr := cfg.AccessTokenDuration
 	duration, err := time.ParseDuration(durationStr)
 	if err != nil {
 		return nil, NewInvalidDurationError(duration, "invalid token duration")

--- a/internal/core/ports/inbound/auth_service.go
+++ b/internal/core/ports/inbound/auth_service.go
@@ -1,12 +1,11 @@
 package inbound
 
 import (
-	"github.com/teamkweku/code-odessey-hex-arch/config"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/auth"
 	"github.com/teamkweku/code-odessey-hex-arch/internal/core/domain/user"
 )
 
 type TokenService interface {
-	CreateToken(user *user.User, cfg config.Config) (string, *auth.Payload, error)
+	CreateToken(user *user.User, durationStr string) (string, *auth.Payload, error)
 	VerifyToken(token string) (*auth.Payload, error)
 }


### PR DESCRIPTION
Replace passing the whole config object to the NewPayload function and rather simplified to take the string of duration to dynamically create access and refresh tokens